### PR TITLE
불필요한 주석 제거 및 영문 주석 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    //mysql 연결
     implementation group: 'com.mysql', name: 'mysql-connector-j', version: '8.2.0'
-
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/tuktuk/domain/reservation/Reservation.java
+++ b/src/main/java/com/example/tuktuk/domain/reservation/Reservation.java
@@ -30,8 +30,4 @@ public class Reservation {
 
     @Embedded
     private Money fee;
-
-    //할인 내역
-
-    //결게 금액 같은 정보 들어감
 }

--- a/src/main/java/com/example/tuktuk/domain/slice/Slice.java
+++ b/src/main/java/com/example/tuktuk/domain/slice/Slice.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "slice")
-public  class Slice {
+public class Slice {
 
     @Id
     @Column(name = "id")

--- a/src/main/java/com/example/tuktuk/domain/slice/Time.java
+++ b/src/main/java/com/example/tuktuk/domain/slice/Time.java
@@ -10,8 +10,6 @@ import java.time.LocalTime;
 @Getter
 @Embeddable
 public class Time {
-
-
     @Column(name = "play_date")
     private LocalDate playDate;
 
@@ -20,6 +18,4 @@ public class Time {
 
     @Column(name = "end_time")
     private LocalTime endTime;
-
-
 }

--- a/src/main/java/com/example/tuktuk/domain/slice/gamematch/Game.java
+++ b/src/main/java/com/example/tuktuk/domain/slice/gamematch/Game.java
@@ -17,7 +17,6 @@ import java.util.List;
 @AllArgsConstructor
 @Table(name = "game")
 public class Game {
-
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/tuktuk/domain/stadium/Court.java
+++ b/src/main/java/com/example/tuktuk/domain/stadium/Court.java
@@ -24,23 +24,21 @@ public class Court {
     @JoinColumn(name = "stadium_id",nullable = false)
     private Stadium stadium;
 
-    @Column(name = "name", nullable = false, columnDefinition = "varchar(64)")
+    @Column(name = "name", nullable = false, length = 64)
     private String Name;
 
     @Enumerated
-    @Column(name = "type",nullable = false)
+    @Column(name = "type", nullable = false)
     private CourtType courtType;
 
-    @Column(name = "hourly_rate",nullable = false)
+    @Column(name = "hourly_rate", nullable = false)
     private int hourlyRentFee;
 
-//    List<String> images;  // 이미지 데이터를 바이트 배열로 저장
+    /*
+        Court의 이미지를 제공하기 위해 S3에 저장된 Court의 엔드포인트 URL을 저장
 
-    /**
-     * image 3장씩 저장해야 하는데, s3 ?? 애는 어케 해야할지 정해야 함
-     *
-     */
-
+        List<String> images;
+    */
     public int getMinParticipants() {
         return courtType.getMinParticipants();
     }

--- a/src/main/java/com/example/tuktuk/domain/stadium/Location.java
+++ b/src/main/java/com/example/tuktuk/domain/stadium/Location.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Enumerated;
 import lombok.Getter;
+import org.hibernate.annotations.Comment;
 
 @Getter
 @Embeddable
@@ -13,12 +14,12 @@ public class Location {
 
     @Enumerated
     @Column(name = "province")
-    private Province province;//도 또는 시
+    private Province province;
 
     @Enumerated
     @Column(name = "city")
-    private City city;//시, 군, 구 등
+    private City city;
 
     @Column(name = "road_address")
-    private String roadNameAddress;//도로명 주소
+    private String roadNameAddress;
 }

--- a/src/main/java/com/example/tuktuk/domain/stadium/Stadium.java
+++ b/src/main/java/com/example/tuktuk/domain/stadium/Stadium.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,13 +18,12 @@ import java.util.List;
 @AllArgsConstructor
 @Table(name = "stadium")
 public class Stadium {
-
     @Id
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", nullable = false, columnDefinition = "varchar(64)")
+    @Column(name = "name", nullable = false, length = 64)
     private String name;
 
     @Embedded
@@ -33,15 +33,10 @@ public class Stadium {
     @Embedded
     private Location location;
 
-    @Column(name = "specific_info", nullable = false, columnDefinition = "text")
-    private String specificInfo; //주차 여부, 찾아 오는 상세한 길 같은 구단 등록주가 상세히 입력하는 폼.
+    @Comment("This column is stadium officials wrote about the stadium in detail")
+    @Column(name = "specific_info", nullable = false, columnDefinition = "TEXT CHECK (LENGTH(specific_info) <= 500)")
+    private String specificInfo;
 
     @OneToMany(mappedBy = "stadium", cascade = CascadeType.ALL)
     private List<Court> courts = new ArrayList<>();
-
-    /**
-     * stadium court에서 연관관계의 주인은 court.
-     * court에서 stadium을 외래키 참조한다.
-     * stadium이 삭제되면, 이와 연관된 court도 삭제되어야 한다. cascade 옵션 모두 사용
-     */
 }

--- a/src/main/java/com/example/tuktuk/domain/stadium/Stadium.java
+++ b/src/main/java/com/example/tuktuk/domain/stadium/Stadium.java
@@ -34,7 +34,7 @@ public class Stadium {
     private Location location;
 
     @Comment("This column is stadium officials wrote about the stadium in detail")
-    @Column(name = "specific_info", nullable = false, columnDefinition = "TEXT CHECK (LENGTH(specific_info) <= 500)")
+    @Column(name = "specific_info", nullable = false, columnDefinition = "text")
     private String specificInfo;
 
     @OneToMany(mappedBy = "stadium", cascade = CascadeType.ALL)

--- a/src/main/java/com/example/tuktuk/domain/user/Password.java
+++ b/src/main/java/com/example/tuktuk/domain/user/Password.java
@@ -5,6 +5,6 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class Password {
-    @Column(name = "password",nullable = false)
+    @Column(name = "password", nullable = false)
     private String value;
 }

--- a/src/main/java/com/example/tuktuk/domain/user/Residence.java
+++ b/src/main/java/com/example/tuktuk/domain/user/Residence.java
@@ -10,12 +10,11 @@ import lombok.Getter;
 @Getter
 @Embeddable
 public class Residence {
-
     @Enumerated
     @Column(name = "province")
-    private Province province;//도 또는 시
+    private Province province;
 
     @Enumerated
     @Column(name = "city")
-    private City city;//시, 군, 구 등
+    private City city;
 }

--- a/src/main/java/com/example/tuktuk/domain/user/User.java
+++ b/src/main/java/com/example/tuktuk/domain/user/User.java
@@ -23,39 +23,41 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Comment("이메일")
-    @Column(name = "username", nullable = false, columnDefinition = "varchar(255)")
-    private String username;
+    @Comment("This column is email address and is provided by SNS")
+    @Column(name = "mail", nullable = false, length = 255)
+    private String mail;
 
     @Embedded
     private Password password;
 
-    @Column(name = "nick_name", nullable = false, columnDefinition = "varchar(16)")
+    @Comment("This column is user name and is provided by SNS")
+    @Column(name = "nick_name", nullable = false, length = 16)
     private String nickName;
 
-    @Column(name = "profile_birth", nullable = false, columnDefinition = "varchar(16)")
+    @Comment("This column is user birthday and is provided by SNS")
+    @Column(name = "profile_birth", nullable = false, length = 16)
     private String profileBirth;
 
-    @Column(name = "gender", nullable = false, columnDefinition = "varchar(3)")
+    @Comment("This column is user gender and is provided by SNS")
+    @Column(name = "gender", nullable = false, length = 3)
     private String gender;
 
-    @Column(name = "tel_no", nullable = false, columnDefinition = "varchar(36)")
+    @Comment("This column is user phone number and is provided by SNS")
+    @Column(name = "tel_no", nullable = false, length = 36)
     private String telNo;
 
-    @Column(name = "created_at", nullable = false, columnDefinition = "datetime")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @Embedded
-    private Residence residence; //경기도 의왕시 내손동, 서울 특별시 중랑구
+    private Residence residence;
 
     @Enumerated
     @Column(name = "role", nullable = false)
     private Role role;
 
 
-    @Comment("소셜 로그인시 갱신됨 (네이버, 카카오, 구글 중 하나)")
-    @Column(name = "provider", nullable = false, columnDefinition = "varchar(36)")
+    @Comment("This column is social login provider (kakao, google, naver)")
+    @Column(name = "provider", nullable = false, length = 36)
     private String provider;
-
-
 }


### PR DESCRIPTION
다음과 같은 변경 사항이 있습니다.

1. @Comment 어노테이션을 통해 Hibernate가 스키마를 생성할 때 일부 컬럼에 영문 주석을 추가하도록 일부 코드에 추가하였습니다. 영문 주석이 추가된 컬럼은 User의 컬럼 중에 SNS 로그인 시에 얻어오는 정보들에 대한 것과 Stadium의 경기장 상세 정보입니다.

2. 기존의 @Column 어노테이션의 columnDefinition을 통해 스키마의 데이터 타입을 작성하던 것이 모두 String 타입의 데이터인 것을 확인하고, length 값만 넣도록 수정하였습니다. (이는 하이버네이트의 Dialect에 따라 자연스럽게 생성되도록 하기 위함입니다.)

단, Stadium의 경기장 상세 정보의 경우 text 타입으로 생성되도록 columnDefinition을 유지하였습니다.